### PR TITLE
Add module assignments for 099–204

### DIFF
--- a/.claude/skills/draft-assignments/SKILL.md
+++ b/.claude/skills/draft-assignments/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: draft-assignments
+description: Draft module assignments for the Cardano Go PBL course. Each assignment requires a working Go code artifact AND learner feedback on the lesson content.
+license: MIT
+compatibility: Customized for the Cardano Go PBL course (Gimbalabs x Blink Labs). Andamio import format.
+metadata:
+  author: Gimbalabs
+  version: 1.0.0
+---
+
+# Skill: Draft Assignments (Cardano Go PBL)
+
+## Description
+
+Generates one assignment per course module for the **Cardano Go PBL** course. An assignment is the *assessment* unit: it asks the learner to produce a reviewable artifact that demonstrates mastery of all the module's SLTs. This skill bakes in the conventions specific to this course (below) so that drafted assignments are completable with current infrastructure, accrete toward the funded DNS CLI project, and can be graded by an agent.
+
+This skill *authors* assignments. It does not grade submissions. Authoring is a Fist-to-Five level-4 task; grading is level-5 — keep them separate.
+
+## Course-Specific Rules (non-negotiable)
+
+These five constraints define every assignment in this course. They override the generic Andamio assignment model.
+
+1. **Artifact = working Go code.** Every assignment produces a runnable Go program, CLI, or package that exercises the module's SLTs against Cardano. No essay-only or screenshot-only assignments. (Exception: the `100` background module and `302` contributing module — see "Module-type exceptions".)
+
+2. **Build toward the DNS CLI.** Where the SLTs allow, frame the artifact as a step the learner could reuse in the Phase 2 funded DNS CLI project (e.g. a command, a chain-query helper, an indexer filter, a tx builder). State the connection explicitly in the Task so completion doubles as DNS CLI onboarding.
+
+3. **Network & infra constraints must be stated.** Assignments run against **preprod** (network magic `1`) unless a reason demands otherwise. Demeter.run is discontinued — never reference it. Always tell the learner which node-access options are valid for that artifact:
+   - Public relay (N2N) — ChainSync / BlockFetch (modules 101, 201)
+   - Blockfrost / Koios (REST) — UTxO queries, tx submission (module 102)
+   - Local Dolos or cardano-node — mempool access (101.4 only)
+   Preview magic is `2`; mainnet is `764824073` (do not assign mainnet work).
+
+4. **Agent-gradable evidence.** Every deliverable must be something an agent can evaluate against the SLTs without watching the learner work: a public repo/gist link, a **preprod transaction hash**, captured stdout/log output, a decoded-CBOR dump, etc. Avoid "the learner demonstrates…" phrasing that requires live observation.
+
+5. **Course feedback is a required deliverable.** To earn each module's credential the learner must submit BOTH the code artifact AND structured feedback on that module's lessons — quality and correctness. See `[[assignments-require-feedback]]`. This is unique to this course: feedback is graded evidence, not optional. The feedback block (below) is mandatory in every assignment.
+
+## Reference Material
+
+Read these before drafting (skip any that are missing, note it):
+
+- **Doctrine:** `~/projects/01-projects/coach/docs/product-course-content-structure.md` → "Assignments" section. One assignment per module; assesses all SLTs; produces one reviewable artifact.
+- **Compile format:** `~/projects/01-projects/coach/skills/compile/SKILL.md` → step 7. Compiled output is `assignment.md` with `# Module Assignment / ## Task / ## Deliverables`. Source convention in `00-course.md` is an `Artifact:` line and `Assessment criteria:` bullets.
+- **CLI / data model:** `~/projects/01-projects/coach/andamio-cli-context.md` → assignment commands. Student submits `.content.evidence` (Tiptap JSON); teacher grades pass/fail via `tx/course/teacher/assignments/assess`.
+- **This course's SLTs:** `outline.md` and `00-course.md` (module sections). These are the targets each assignment must cover.
+
+## Instructions
+
+### 1. Identify the module and its SLTs
+
+The user names a module (e.g. `201`) or says "all modules". For each, read its SLTs from `outline.md` / `00-course.md`. List them — the assignment must give coverage to every SLT in the module.
+
+### 2. Choose the artifact
+
+Pick one coherent Go artifact that exercises *all* the module's SLTs together (not one micro-task per SLT). Prefer something the learner can extend into the DNS CLI. Examples by module:
+
+| Module | Candidate artifact |
+|--------|--------------------|
+| 099 | A small multi-command Cobra CLI with a Fiber endpoint, debugged and type-checked |
+| 101 | A Go program that connects via gOuroboros, fetches a block, and reports sync tip |
+| 102 | A CLI command that builds, signs, and submits a preprod tx with Bursa + Apollo |
+| 201 | An Adder pipeline that filters events by address/policy/pool and logs matches |
+| 202 | A query layer that stores indexed data and reconciles it with a provider query |
+| 203 | A tx builder that mints/locks/unlocks with a validator and watches the result via Adder |
+| 204 | A tool that decodes on-chain CBOR datums/redeemers and re-encodes a modified value |
+
+### 3. Write the assignment
+
+Write each assignment as a **standalone file** at `lessons/{module_code}/assignment.md`. Use this exact structure — a top-level H1 title, then the course-standard sections. Task + Deliverables map cleanly onto the compiled `assignment.md`; Assessment Criteria and the Course Feedback deliverable are the course-specific additions.
+
+```markdown
+# Assignment {module_code}: {short title}
+
+## Artifact
+
+{one sentence — the working Go artifact the learner submits}
+
+## Required Task
+
+{2–4 sentences. What the learner builds and why. Name the libraries (Bursa/Apollo/Adder/gOuroboros). State the DNS CLI connection. State the network: preprod (magic 1) and the valid node-access option(s) for this artifact. Break into short paragraphs rather than one dense block.}
+
+## Additional Exploration
+
+{Optional stretch goal that varies a constraint from the Required Task — a different network (Preview, magic 2), a different tool, or a harder target — and nudges the learner toward independent research. Keep it genuinely optional; the credential is earned by the Required Task + Deliverables.}
+
+## Deliverables
+
+1. {Code artifact — public repo or gist link to runnable Go code}
+2. {Runtime evidence — preprod tx hash, captured output/logs, or decoded-CBOR dump, as appropriate}
+3. {Any SLT-specific evidence not covered above}
+4. **Course feedback (required):** Written feedback on this module's lessons covering:
+   - **Quality** — what was clear, what was confusing, what was missing.
+   - **Correctness** — any code that didn't run, commands that failed, steps that were wrong or out of date (include the lesson number).
+
+## Assessment Criteria
+
+{For the grader/agent. One bullet per SLT, each stating the observable pass condition.}
+- **SLT {module}.{n}** — pass when {observable condition in the submitted evidence}.
+- ...
+- **Course feedback** — pass when feedback is specific and lesson-referenced (not "it was good"); flags at least one correctness issue OR one concrete improvement.
+
+## Notes
+
+{Optional: on-chain cost/faucet reminder for preprod, common mistakes, timing.}
+```
+
+### 4. Coverage check
+
+Before finishing, verify:
+
+- [ ] Every SLT in the module maps to at least one Deliverable and one Assessment Criterion.
+- [ ] The artifact is runnable Go code (or a justified module-type exception).
+- [ ] Network is preprod (magic `1`) and valid node-access options are named; no Demeter reference.
+- [ ] Every Deliverable is agent-gradable evidence (link / tx hash / output), not live observation.
+- [ ] The required Course Feedback deliverable is present.
+- [ ] The DNS CLI connection is stated where the SLTs allow.
+
+### 5. Where to write it
+
+Write the assignment to its own standalone file at `lessons/{module_code}/assignment.md` (one file per module, alongside that module's lessons). This is the source of truth — do **not** also embed the assignment in `00-course.md`. When the module is compiled, this file becomes the module's `assignment.md`; fold the Course Feedback item into the Deliverables list at compile time if a stricter `# Module Assignment / ## Task / ## Deliverables` shape is required.
+
+### Module-type exceptions
+
+- **099 (Intro to Go)** is pure Go — no Cardano node, network, keys, or testnet. The preprod/magic and node-access rules do **not** apply; the artifact runs against in-memory/test data.
+- **100 (Prerequisites + Tools)** pairs a hands-on artifact with short written explanations. Have the learner **create a wallet with Bursa** — concrete proof the toolchain is set up (grounds 100.3 and 100.7) — alongside a brief "tools field guide" covering the explain-only SLTs (100.1, 100.2, 100.4–100.6). Never ask the learner to submit secrets: evidence is the public address + faucet funding, not the mnemonic or signing keys.
+- **302 (contributing)** artifact is a real PR to a Blink Labs repository (artifact = the PR link). The Course Feedback deliverable is still required.
+- **301 (debugging)** artifact is a debrief of a real bug the learner diagnosed (repro, root cause, fix), plus the fixed code.
+
+### After drafting
+
+Suggest the user:
+1. Review the assignment with the team.
+2. Run `/compile {module}` to package it for Andamio import.
+3. Update the placeholder `assignment` object in `course-upload.json` (currently `"Assignment Title"` for every module) with the real title/description.

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,15 @@
 # Lesson Coach symlinks (machine-specific, recreated via setup script)
 knowledge
 research
-.claude/skills/
+.claude/skills/assess-slts
+.claude/skills/classify-lesson-types
+.claude/skills/compile
+.claude/skills/compound
+.claude/skills/course-workflow
+.claude/skills/draft-slts
+.claude/skills/gather-code-examples
+.claude/skills/gather-screenshots
+.claude/skills/self-assess-readiness
 
 # OS
 .DS_Store
@@ -9,3 +17,4 @@ research
 # Editor
 *.swp
 *~
+.obsidian/

--- a/00-course.md
+++ b/00-course.md
@@ -96,10 +96,10 @@ Build transactions that interact with smart contracts.
 
 - **203.1**: I can trace how a type defined in Aiken appears in a blueprint file and in Go code.
 - **203.2**: I can build a transaction that mints or burns tokens using a native script (no smart contract required).
-- **203.3**: I can build a transaction that mints or burns tokens using a validator script (smart contract).
-- **203.4**: I can build a transaction that unlocks tokens held by a smart contract.
-- **203.5**: I can build a transaction that attaches data to a new output on the blockchain.
-- **203.6**: I can build a transaction that passes input data to a smart contract using a redeemer.
+- **203.3**: I can build a transaction that attaches data to a new output on the blockchain.
+- **203.4**: I can build a transaction that unlocks funds held by a smart contract.
+- **203.5**: I can build a transaction that passes input data to a smart contract using a redeemer.
+- **203.6**: I can build a transaction that mints or burns tokens using a validator script (smart contract).
 
 ### Module 204: Serializing Data
 

--- a/lessons/099/assignment.md
+++ b/lessons/099/assignment.md
@@ -1,0 +1,48 @@
+# Assignment 099: Address Balance Toolkit
+
+## Artifact
+
+A single small Go project that calculates a Cardano address balance from a set of UTxOs and exposes it two ways — as a multi-command Cobra CLI and as a Fiber HTTP API — with the balance logic sitting behind an interface and covered by tests.
+
+## Required Task
+
+Welcome to the course — this is your first project. You won't touch a Cardano node yet; the goal here is to get comfortable building real Go programs, because everything later in the course is built on these foundations. By the end you'll have a small working tool that is, quite literally, the skeleton of the **DNS CLI** you'll grow over the rest of the course.
+
+Build one project that ties the module together:
+
+- Model a `UTxO` as a struct and compute an address's total balance, with the calculation depending on a small `UTxOLoader` **interface** rather than a concrete data source (099.2). Ship an in-memory fake loader so the whole thing runs with no external services.
+- Write a test that **reproduces and then fixes** a balance bug — the classic one where a loop *replaces* the running total instead of accumulating it. Show the test failing, then passing after your fix, and name the tool you used to find it (`go test`, a print, `dlv`, `go vet`, or `-race`) (099.1).
+- Expose the balance through a **Cobra CLI** with at least two subcommands (e.g. `balance --address <addr>` and `version`) and a persistent `--json` flag, returning a clear error on missing input (099.3).
+- Expose the same balance through a **Fiber API** — `GET /health` and `GET /balance/:address` returning JSON (099.4).
+
+The CLI and the API should both call the *same* balance service over the *same* loader interface — that's the "parts fit together" idea in 099.2 made concrete.
+
+## Additional Exploration
+
+Add a second `UTxOLoader` that reads UTxOs from a JSON file (or stdin) and a flag to pick which loader to use. This is exactly how the course will later swap your fake loader for a real Cardano data source — so doing it now means the rest of the course just plugs in. As a lighter stretch, write a concurrent version of the balance sum and run `go test -race` to prove it's safe.
+
+## Deliverables
+
+1. **Code** — public repo or gist with the runnable project: `UTxO` struct, `UTxOLoader` interface, balance service, in-memory fake loader, tests, the Cobra CLI, and the Fiber API. README says how to run the CLI and the server.
+2. **Test evidence** — captured `go test ./...` output showing your balance tests pass, **including** the regression test for the accumulation bug. Add one line naming which debugging tool located the bug and why.
+3. **Running evidence** — captured output showing both surfaces return the same balance:
+   - CLI: `balance --address <addr>` plain, and again with `--json`.
+   - API: `curl` responses from `/health` and `/balance/:address`.
+4. **Course feedback (required):** Written feedback on Module 099's lessons covering:
+   - **Quality** — what was clear, what was confusing, what was missing.
+   - **Correctness** — any code that didn't run, commands that failed, or steps that were wrong/out of date (cite the lesson number, e.g. 099.3).
+
+## Assessment Criteria
+
+- **SLT 099.1** — pass when a regression test reproduces a balance bug (submission shows it failing, then passing after the fix) and the learner names the debugging tool they used.
+- **SLT 099.2** — pass when the balance logic depends on a `UTxOLoader` interface and a fake/in-memory loader is substituted in tests without changing the service code.
+- **SLT 099.3** — pass when the CLI runs at least two subcommands with a flag and returns a clear, deterministic error on invalid input (e.g. missing `--address`).
+- **SLT 099.4** — pass when the Fiber server starts and `/health` plus a balance route return correct JSON for a given address.
+- **Course feedback** — pass when feedback is specific and lesson-referenced (not "it was good"); flags at least one correctness issue OR one concrete improvement.
+
+## Notes
+
+- **No Cardano node, network, keys, or testnet needed** — this module is pure Go, run entirely against your in-memory fake loader. (The network magic / preprod rules from later modules do not apply here.)
+- Keep the project layout from the lessons: a thin `main.go`, commands under `cmd/`, app logic under `internal/`. You'll reuse this exact structure when the CLI gains Cardano commands.
+- Hold on to this repo — later modules replace the fake loader with real chain-backed loaders (gOuroboros, Adder, Blockfrost), turning this skeleton into the DNS CLI.
+- This is the on-ramp: if you can finish this, you're ready for the rest of the course. Aim for "working and clear," not clever.

--- a/lessons/100/assignment.md
+++ b/lessons/100/assignment.md
@@ -1,0 +1,49 @@
+# Assignment 100: Create Your Wallet, Map the Toolchain
+
+## Artifact
+
+A Bursa-generated preprod wallet (funded from the faucet) plus a short written "field guide" to the Blink Labs tools — proving your environment is set up and that you understand what each tool is for before you start building.
+
+## Required Task
+
+This module is about getting oriented: what Cardano is, how it reaches consensus, and why the tools you're about to use exist. Your assignment turns that orientation into something concrete — you'll create a real wallet and write down, in your own words, what each tool solves.
+
+**Create a wallet with Bursa.** Using Bursa (a tiny Go program against [`github.com/blinklabs-io/bursa`](https://github.com/blinklabs-io/bursa), or the Bursa CLI), generate a new wallet for **preprod**: a mnemonic, payment and stake keys, and a bech32 address. Then **fund that address from the preprod faucet** so it holds some test ADA. This is the wallet you'll reuse to build transactions in Module 102, so keep it — but treat the keys correctly (see the security note).
+
+**Write a short tools field guide.** A few sentences each, in your own words:
+- What makes Cardano distinct — at least one concrete difference (e.g. the eUTxO model vs. an account model). *(100.1)*
+- How Ouroboros reaches consensus, at a high level (stake-based slot leaders, epochs). *(100.2)*
+- The problem each tool solves: **Bursa** *(100.3)*, **Apollo** *(100.4)*, **Adder** *(100.5)*, **Cardano Up** *(100.6)*.
+
+The wallet you just made is the identity your **DNS CLI** will later sign name registrations with — setting it up now means every later module has a funded wallet ready to go.
+
+## Additional Exploration
+
+Prove the wallet is deterministic: restore it from its mnemonic with Bursa and confirm you get the same address back. As a second stretch, use **Cardano Up** to stand up part of a local stack and note what it automated for you — grounding 100.6 in something you actually ran.
+
+## Deliverables
+
+1. **Setup artifact** — the small Go program or the exact Bursa CLI command(s) you used to generate the wallet, in a public repo/gist or pasted with **all secret material redacted**.
+2. **Wallet evidence** — your generated preprod **payment address**, plus a **faucet/funding transaction hash** showing the address holds test ADA, cross-checkable on [Cardanoscan Preprod](https://preprod.cardanoscan.io/). **Do not submit the mnemonic or signing keys.**
+3. **Tools field guide** — your written answers covering Cardano's distinctiveness, Ouroboros, and why Bursa / Apollo / Adder / Cardano Up each exist.
+4. **Course feedback (required):** Written feedback on Module 100's lessons covering:
+   - **Quality** — what was clear, what was confusing, what was missing.
+   - **Correctness** — any code that didn't run, commands that failed, or steps that were wrong/out of date (cite the lesson number, e.g. 100.3).
+
+## Assessment Criteria
+
+- **SLT 100.1** — pass when the field guide names at least one concrete way Cardano differs from other blockchains (e.g. eUTxO vs. account model).
+- **SLT 100.2** — pass when it correctly sketches, at a high level, how Ouroboros reaches consensus (stake-based slot leadership / epochs).
+- **SLT 100.3** — pass when the learner explains the problem Bursa solves **and** has actually created a wallet with it (address provided).
+- **SLT 100.4** — pass when the field guide explains why Apollo exists (building transactions in Go).
+- **SLT 100.5** — pass when it explains why Adder exists (following/indexing chain events).
+- **SLT 100.6** — pass when it explains why Cardano Up exists (automating environment setup).
+- **SLT 100.7** — pass when the funded preprod address demonstrates a working Go + Blink Labs dev environment.
+- **Course feedback** — pass when feedback is specific and lesson-referenced (not "it was good"); flags at least one correctness issue OR one concrete improvement.
+
+## Notes
+
+- **Security:** never commit or submit the mnemonic or signing keys. It's a throwaway preprod wallet, but practise safe key handling now — submit only the public address and funding evidence. Keep keys in a file that's gitignored or in an environment variable.
+- Wallet generation with Bursa is **offline** (local key derivation); only the faucet funding step touches the network. No node access is required for this module — preprod magic is `1`.
+- This wallet carries forward to Module 102 (build a transaction with Apollo) — don't throw it away.
+- _Lesson content for Module 100 is only partially written (4 of 7 lessons) and the module may be deprioritized; reconcile this assignment against the lessons once they're finalized._

--- a/lessons/101/assignment.md
+++ b/lessons/101/assignment.md
@@ -1,0 +1,49 @@
+# Assignment 101: Node Inspector CLI
+
+## Artifact
+
+A small multi-command Go CLI, built on gOuroboros, that connects to a Cardano node and reports on it: current chain tip and sync state, the contents of a specific block, and the node's pending mempool.
+
+## Required Task
+
+Using the gOuroboros Starter Kit as your starting point, build a command-line tool that talks directly to a Cardano node over the Ouroboros protocols. Give it commands that each exercise a different mini-protocol:
+
+- **tip / sync** — connect via ChainSync and report the chain tip and how far the node has synced.
+- **block** — fetch a specific block via BlockFetch and print its identifying fields (slot, hash, transaction count).
+- **mempool** — query the node's pending transactions via LocalTxMonitor.
+
+This is the node-interaction plumbing the **DNS CLI** sits on: before it can register or resolve a name, it needs to reach a node, know the chain is current, read blocks, and see what's pending. A Cobra structure here also carries straight over from 099.3.
+
+The first three commands run over **Node-to-Node (N2N)** against a public **preprod** relay (magic `1`) — e.g. `preprod-node.world.dev.cardano.org:3001` (more relays in the [Cardano environments list](https://book.play.dev.cardano.org/environments.html)). The `mempool` command uses **Node-to-Client (N2C)** over a local Unix socket and therefore **requires a local node** — Dingo (Preview, magic `2`) or cardano-node in Docker. If you don't run a local node, complete the first three commands against a relay and note the mempool command as infra-blocked.
+
+## Additional Exploration
+
+Close the loop with submission: send a transaction (reuse your Module 102 wallet/builder, or the starter kit's TxSubmission path) and have your `mempool` command show it sitting in the local node's mempool *before* it's included in a block. As a lighter stretch, point `tip` at two different relays and observe whether they report the same tip slot.
+
+## Deliverables
+
+1. **Code** — public repo or gist with the runnable CLI (gOuroboros, multi-command). The README lists each command and how to run it.
+2. **Runtime evidence** — captured terminal output for each capability:
+   - **tip/sync** — connection established plus the reported chain tip and sync state.
+   - **block** — a specific block's slot, hash, and transaction count.
+   - **mempool** — the query result (pending transaction hashes, or an explicit "mempool empty").
+   Include the tip slot/block hash so it can be cross-checked on [Cardanoscan Preprod](https://preprod.cardanoscan.io/).
+3. **Connection note** — for each command, which access mode and endpoint you used (public relay over N2N vs. local node over N2C) and the network magic.
+4. **Course feedback (required):** Written feedback on Module 101's lessons covering:
+   - **Quality** — what was clear, what was confusing, what was missing.
+   - **Correctness** — any code that didn't run, commands that failed, or steps that were wrong/out of date (cite the lesson number, e.g. 101.2).
+
+## Assessment Criteria
+
+- **SLT 101.1** — pass when the code connects to a node via gOuroboros (ChainSync, N2N) and the output shows a live connection.
+- **SLT 101.2** — pass when the code fetches a *specific* block via BlockFetch and the output shows that block's identifying fields (slot, hash).
+- **SLT 101.3** — pass when the program reports the node's sync state — the chain tip and how far the node has synced toward it.
+- **SLT 101.4** — pass when the program queries the mempool via LocalTxMonitor against a local node and the output shows the result (pending tx hashes or an explicit empty mempool). _Requires a local node; if infra-blocked, the learner must show the working code and a clear account of the blocker._
+- **Course feedback** — pass when feedback is specific and lesson-referenced (not "it was good"); flags at least one correctness issue OR one concrete improvement.
+
+## Notes
+
+- Network magic: preprod = `1`, preview = `2`, mainnet = `764824073` (do not target mainnet).
+- **101.4 is the only part that needs a local node.** Dingo is the all-Go option (Preview, ~50 GB, Mithril snapshot bootstrap); cardano-node in Docker is the stable fallback. Both expose the N2C socket LocalTxMonitor needs.
+- Preprod mempool is often empty between transactions — the Additional Exploration (submit your own tx) is the reliable way to see a non-empty result.
+- _Lesson content for Module 101 is not yet written; this assignment is drafted from the SLTs and `infrastructure-options.md`. Reconcile command names and APIs against the lessons once they exist._

--- a/lessons/102/assignment.md
+++ b/lessons/102/assignment.md
@@ -1,0 +1,52 @@
+# Assignment 102: Transaction Sender
+
+## Artifact
+
+A Go command that builds a preprod transaction with Apollo from a Bursa-managed wallet — with a validity window and attached metadata — and demonstrates both signing modes, submitting the programmatically-signed transaction to a node with gOuroboros.
+
+## Required Task
+
+This is the module where you make the chain *do* something. Build a small program (a new command on your 099 CLI skeleton is ideal) that takes a transaction all the way from intent to a confirmed on-chain event.
+
+- Use a **Bursa** wallet as the sender — reuse the wallet you created in Module 100, or create a fresh one with Bursa (`go run ./cmd/bursa wallet create`). This wallet supplies the address and keys (102.1).
+- Build a balanced ADA payment with **Apollo** using a Blockfrost preprod ChainContext to fetch UTxOs and protocol parameters; let Apollo handle input selection, fees, and change (102.2).
+- **Set a validity window** on the transaction (a TTL / `invalid_hereafter` slot) (102.5), and **attach simple metadata** under a label of your choice (102.6).
+- Demonstrate **both signing modes** (102.3): sign programmatically in Go with Apollo, *and* export the unsigned transaction CBOR and sign + submit it from a wallet.
+- **Submit the programmatically-signed transaction to a node with gOuroboros** (102.4) — i.e. via Ouroboros TxSubmission to a node, not only through Blockfrost's REST submit.
+
+This is the DNS CLI's core write path in miniature: the CLI's job is ultimately to build, sign, and submit transactions — and to carry a payload (here, metadata) that represents a name record.
+
+## Additional Exploration
+
+Make the metadata mean something: store a fake **DNS record** (a `name → value` mapping) under a chosen metadata label, then write a tiny reader that fetches the transaction back and pulls the record out of its metadata. That's a direct rehearsal of what the DNS CLI does. As a second stretch, submit via a **local node over N2C** instead of a public relay and note what changed.
+
+## Deliverables
+
+1. **Code** — public repo or gist with the runnable command (Bursa wallet → Apollo build → validity window + metadata → sign → gOuroboros submit). README explains how to run it and which preprod relay/node you submitted to.
+2. **Unsigned CBOR** — the hex string your program exports *before* signing, showing a balanced transaction body (with your metadata and validity window) and no witnesses. This is the artifact you hand to a wallet for manual signing.
+3. **Two confirmed transactions on [Cardanoscan Preprod](https://preprod.cardanoscan.io/)** — include both tx hashes:
+   - **Programmatic + gOuroboros** — built and signed in Go, submitted to a node via gOuroboros.
+   - **Manual** — the exported unsigned CBOR, signed and submitted from a wallet.
+   At least one must visibly show your **attached metadata** and **validity window** on the explorer.
+4. **Course feedback (required):** Written feedback on Module 102's lessons covering:
+   - **Quality** — what was clear, what was confusing, what was missing.
+   - **Correctness** — any code that didn't run, commands that failed, or steps that were wrong/out of date (cite the lesson number, e.g. 102.2).
+
+## Assessment Criteria
+
+- **SLT 102.1** — pass when a Bursa-managed wallet supplies the sender address/keys (address shown; created or loaded via Bursa).
+- **SLT 102.2** — pass when a balanced ADA transaction built with Apollo (Apollo handling UTxO selection, fees, and change) lands on chain.
+- **SLT 102.3** — pass when **both** signing modes are evidenced: programmatic (Apollo `Sign()` in Go) and manual (unsigned CBOR exported, then signed/submitted via a wallet).
+- **SLT 102.4** — pass when at least one transaction is submitted to a node via **gOuroboros** (not only Blockfrost), with the resulting tx hash.
+- **SLT 102.5** — pass when a transaction sets a validity window (TTL / `invalid_hereafter`), visible on the explorer or in the exported tx body.
+- **SLT 102.6** — pass when a transaction carries simple metadata, visible on the explorer.
+- **Course feedback** — pass when feedback is specific and lesson-referenced (not "it was good"); flags at least one correctness issue OR one concrete improvement.
+
+## Notes
+
+- Libraries: **Bursa** (`github.com/blinklabs-io/bursa`), **Apollo** (`github.com/Salvionied/apollo`), **gOuroboros** (`github.com/blinklabs-io/gouroboros`). Building uses a **Blockfrost preprod** ChainContext for UTxOs + protocol params; preprod network magic is `1`.
+- Lessons 102.2/102.3 submit via Blockfrost — that's the baseline. For **102.4** you submit the signed CBOR to a node through gOuroboros TxSubmission: a public preprod relay over N2N works (e.g. `preprod-node.world.dev.cardano.org:3001`), or a local node.
+- **Security:** keep the mnemonic and signing keys out of git (a gitignored Bursa wallet dir or `.env`). Submit only tx hashes and the public address — never secrets.
+- Set `invalid_hereafter` to a slot comfortably in the future; too tight and the tx can expire before the node accepts it.
+- Fund the sender from the preprod faucet first, and wait for prior transactions to confirm so your UTxOs aren't pending.
+- _Lesson content for 102.4–102.6 is not yet written; this assignment is drafted from the SLTs and the written 102.1–102.3 lessons. Reconcile command names and APIs once those lessons exist._

--- a/lessons/201/assignment.md
+++ b/lessons/201/assignment.md
@@ -1,0 +1,39 @@
+# Assignment 201: Filtered Chain Watcher
+
+## Artifact
+
+A Go indexer built on Adder that connects to Cardano Preprod, follows the chain, and applies a composed pipeline filter (event type + address/policy/pool), logging only matched events.
+
+## Required Task
+
+Starting from the Adder starter kit, build a small indexer that connects Adder to Cardano Preprod (network magic `1`) and uses Adder's pipeline filters to report only the events you care about. 
+
+Composing an event-type filter with one of address, policy ID, or stake-pool filtering. This is the seed of the **DNS CLI's "watch" capability**: a daemon that surfaces only the on-chain events relevant to a name registry (e.g. transactions touching a registry address, or mints under a name-token policy). 
+
+Connect either through your local **Dolos** Unix socket (`WithSocketPath`) or a **public preprod relay** over TCP (`WithAddress("preprod-node.world.dev.cardano.org:3001")`). Both speak Ouroboros N2N, which is all Adder needs.
+
+## Additional Exploration
+
+Instead of connecting to Cardano Preprod, connect to Cardano Preview. Build a Go indexer that tracks blocks minted with Dingo. (You will need to do some social and/or technical research to determine which Preview stake pools are running Dingo.)
+
+## Deliverables
+
+1. **Code** — public repo or gist with runnable Go using Adder (the starter-kit pattern). The README states which connection mode you used and shows your filter configuration.
+2. **Runtime evidence** — captured terminal output showing (a) the ChainSync status update confirming a successful connection to preprod, and (b) at least one event passing your composed filter. Include the matched transaction hash or block issuer so it can be cross-checked on [Cardanoscan Preprod](https://preprod.cardanoscan.io/).
+3. **Filter rationale** — a short note naming which filter types you composed and what real preprod activity you targeted (which address/policy/pool, and why it has activity).
+4. **Course feedback (required):** Written feedback on Module 201's lessons covering:
+   - **Quality** — what was clear, what was confusing, what was missing.
+   - **Correctness** — any code that didn't run, commands that failed, or steps that were wrong/out of date (cite the lesson number, e.g. 201.3).
+
+## Assessment Criteria
+
+- **SLT 201.1** — pass when the submitted code follows the Adder starter-kit pattern and the captured output shows a successful ChainSync connection with events streaming.
+- **SLT 201.2** — pass when the submission states the connection mode used and the config shows the correct preprod magic (`1`) with a valid socket path or relay address (N2N).
+- **SLT 201.3** — pass when the pipeline composes a `filter_event` (type) with a `filter_chainsync`/`filter_cardano` filter on address, policy, **or** pool, and the output shows only matching events (other traffic dropped).
+- **Course feedback** — pass when feedback is specific and lesson-referenced (not "it was good"); flags at least one correctness issue OR one concrete improvement.
+
+## Notes
+
+- Module 201 produces no transactions of your own — you're *observing*. Pick a target with real preprod activity: e.g. the Andamio access-token policy `29aa6a65f5c890cfa428d59b15dec6293bf4ff0a94305c957508dc78`, your own tokens from Module 102, or an active pool from Cardanoscan Preprod.
+- Block-level **pool** filtering can take minutes between matches — be patient, or choose address/policy filtering for faster evidence.
+- Adder **v0.36.0+** renames `filter/chainsync` to `filter/cardano` (identical API). Note your version from `go.mod`.

--- a/lessons/202/assignment.md
+++ b/lessons/202/assignment.md
@@ -1,0 +1,43 @@
+# Assignment 202: Hybrid Address Indexer
+
+## Artifact
+
+A Go indexer that maintains a queryable local store of all transactions for a watched address — backfilled with history from a query provider and kept current with live Adder events — with rollback handling and a written provider-selection rationale.
+
+## Required Task
+
+Extend the Adder pipeline from Module 201 into a small custom indexer that answers a question a live event stream alone cannot: *what is the complete transaction history of this address, past and present?*
+
+Persist matched transactions to a local store (SQLite is fine), backfill the address's earlier history from a query provider at startup, and keep the store current by writing each live event as it arrives. Handle `chainsync.rollback` events so orphaned transactions don't linger. This is the seed of the **DNS CLI's "registry state" layer**: a local, queryable record of every on-chain event affecting a name — built once from history and maintained live thereafter.
+
+Connect live data through your local **Dolos** Unix socket (ChainSync, magic `1`) and backfill history through **Blockfrost preprod** (or another provider you justify). Both run against Cardano Preprod.
+
+## Additional Exploration
+
+Put a query interface in front of your store: serve the combined history over an HTTP endpoint (e.g. a Fiber route from 099.4) so the indexer becomes a service, not just a script. As a second stretch, swap Blockfrost for **Koios** on the backfill path and note what changed — auth, response shape, rate limits — and which you'd choose for the DNS CLI.
+
+## Deliverables
+
+1. **Code** — public repo or gist with the runnable indexer (Adder live stream + persistent store + provider backfill + rollback handler). The README shows how to run it and names the watched address.
+2. **Combined-data evidence** — captured query output (e.g. `sqlite3 indexer.db "SELECT source, block_height, slot, tx_hash ..."`) showing rows from **both** sources for the same address: live rows (`source=adder`, `slot` populated) *and* historical rows (`source=blockfrost`, `block_height` populated), with duplicates absent. Include one transaction hash so it can be cross-checked on [Cardanoscan Preprod](https://preprod.cardanoscan.io/).
+3. **Provider rationale** — a short written note (in the README is fine) covering: what your indexer indexes and why a stored/query layer is needed beyond the live event handler; which provider you chose for backfill and its trade-offs against the alternatives (Blockfrost / Koios / Maestro / Kupo / DB Sync / Dolos).
+4. **Course feedback (required):** Written feedback on Module 202's lessons covering:
+   - **Quality** — what was clear, what was confusing, what was missing.
+   - **Correctness** — any code that didn't run, commands that failed, or steps that were wrong/out of date (cite the lesson number, e.g. 202.4).
+
+## Assessment Criteria
+
+- **SLT 202.1** — pass when the rationale explains what a blockchain indexer does and names at least one concrete trade-off of running one (infra, freshness, history depth, or cost).
+- **SLT 202.2** — pass when the rationale identifies why the live event handler alone cannot answer the target question (history before startup) and justifies the query-based backfill.
+- **SLT 202.3** — pass when the code persists live Adder events to a store and the submitted evidence shows data being **retrieved** (query output), not just written.
+- **SLT 202.4** — pass when a query provider is chosen for backfill with stated trade-offs against at least one named alternative.
+- **SLT 202.5** — pass when the query output shows **both** live (`source=adder`) and historical (`source=blockfrost`) rows for the same address in one store, deduplicated by `tx_hash`.
+- **Course feedback** — pass when feedback is specific and lesson-referenced (not "it was good"); flags at least one correctness issue OR one concrete improvement.
+
+## Notes
+
+- Generate a live row by sending a transaction to your watched address from the [preprod faucet](https://docs.cardano.org/cardano-testnets/tools/faucet) or another wallet *after* the pipeline is running — Adder tails from the tip.
+- A Blockfrost preprod project ID starts with `preprod`; keep it in a `.env` file, never commit it.
+- `INSERT OR IGNORE` on a `UNIQUE(tx_hash)` column is what dedupes the two sources — make sure your schema has it.
+- Rollbacks are rare on preprod; you likely won't observe one in a session. The handler is graded for **correctness** (deletes rows with `slot >` the rollback slot), not for being triggered live.
+- Adder **v0.36.0+** renames `filter/chainsync` to `filter/cardano` (identical API). Note your version from `go.mod`.

--- a/lessons/203/assignment.md
+++ b/lessons/203/assignment.md
@@ -1,0 +1,55 @@
+# Assignment 203: Hello World Contract Lifecycle
+
+## Artifact
+
+A Go program that drives the module's `hello_world` validator through its full lifecycle on preprod — building the datum and redeemer from the blueprint, minting with a native script and with the validator, locking funds with a datum, and unlocking them with a redeemer — while an Adder watcher observes each transaction land.
+
+## Required Task
+
+This is where your Go code meets on-chain logic. Using the module's `hello_world` Aiken contract and its `plutus.json` blueprint (you're *reading* the blueprint, not writing Aiken), build a program that exercises every kind of smart-contract interaction the module covers, all against the same validator:
+
+- **Read the blueprint into Go** — construct the `Datum` (`owner`) and `Redeemer` (`msg`) as Apollo `PlutusData`, matching the blueprint's constructor tag and field order exactly (203.1).
+- **Mint or burn with a native script** — a token under a native-script policy, no validator required (203.2).
+- **Lock funds with a datum** — pay to the validator's script address with a `Datum` attached to the output, where `owner` is your wallet's payment key hash (203.3).
+- **Unlock those funds** — spend the locked UTxO, passing the `Redeemer` (`msg = "HelloSpendRedeemer"`) and signing with the `owner` key so the validator's `must_say_hello && must_be_signed` check passes (203.4 + 203.5).
+- **Mint or burn with the validator script** — invoke the contract's `mint` handler with `msg = "HelloMintRedeemer"` (203.6).
+- **Watch it happen** — run an Adder watcher (from Module 201) and capture your transactions landing on-chain.
+
+This is the most direct preview of the **DNS CLI** yet: a name registry *is* a validator holding records in datums, updated by the owner through redeemers, with name-tokens minted under a policy. You're building that machinery here on a toy contract.
+
+## Additional Exploration
+
+Turn `hello_world` into a tiny name registry: extend the `Datum` with a second field (a record string alongside `owner`, exactly as the multi-field example in 203.1 shows), lock a "name record" with it, then unlock it. Point a **filtered Adder watcher** at the script address and confirm the datum you attached shows up in the observed transaction.
+
+## Deliverables
+
+1. **Code** — public repo or gist with the runnable program (blueprint → `PlutusData`, native mint, lock-with-datum, unlock-with-redeemer, validator mint) plus the Adder watcher. README explains how to run each step.
+2. **PlutusData mapping** — show your Go `Datum` and `Redeemer` construction and a one-line trace of how each maps back to the blueprint `definitions` (constructor → tag 121, fields in order, `#bytes` → `PlutusBytes`).
+3. **Confirmed transactions on [Cardanoscan Preprod](https://preprod.cardanoscan.io/)** — tx hashes for each:
+   - native-script **mint/burn** (203.2),
+   - an output that **locks funds at the script address with a datum** (203.3),
+   - a transaction that **unlocks** those funds, passing the redeemer and owner signature (203.4 + 203.5),
+   - a **validator-script mint/burn** (203.6).
+4. **Adder evidence** — captured output from your watcher showing at least one of these transactions detected on-chain.
+5. **Course feedback (required):** Written feedback on Module 203's lessons covering:
+   - **Quality** — what was clear, what was confusing, what was missing.
+   - **Correctness** — any code that didn't run, commands that failed, or steps that were wrong/out of date (cite the lesson number, e.g. 203.4).
+
+## Assessment Criteria
+
+- **SLT 203.1** — pass when the Go code builds `Datum` and `Redeemer` as `PlutusData` matching the blueprint (constructor tag `121`, correct field order and `#bytes` types), with a trace to the `definitions`.
+- **SLT 203.2** — pass when a transaction mints or burns a token using a **native script**, confirmed on-chain.
+- **SLT 203.3** — pass when a transaction creates an output at the **validator's script address with a datum attached**.
+- **SLT 203.4** — pass when a transaction **spends (unlocks)** the funds held at the script address.
+- **SLT 203.5** — pass when that unlock **supplies the redeemer** (`HelloSpendRedeemer`) and the required `owner` signature, satisfying the validator.
+- **SLT 203.6** — pass when a transaction mints or burns using the **validator (Plutus) script** with the `HelloMintRedeemer` redeemer.
+- **Course feedback** — pass when feedback is specific and lesson-referenced (not "it was good"); flags at least one correctness issue OR one concrete improvement.
+
+## Notes
+
+- Use the module's **`hello_world`** validator and its `plutus.json` — no Aiken authoring required (you read the blueprint, per 203.1). Compiling and *parameterizing* contracts comes later, in 204.2.
+- Libraries: **Apollo** (`PlutusData`, building, script context), a **Blockfrost preprod** ChainContext, and **Adder** for observation. Preprod network magic is `1`.
+- The datum's `owner` must be **your wallet's payment key hash**, and the unlock transaction must be **signed by that key** (it lands in `extra_signatories`) — the validator checks `list.has(self.extra_signatories, owner)`.
+- The redeemer `msg` is **bytes, not a string**: `[]byte("HelloSpendRedeemer")` / `[]byte("HelloMintRedeemer")`.
+- Wrong `PlutusData` shape or field order produces a transaction the validator silently rejects — inspect the unsigned tx and build up one step at a time.
+- _Heads-up: `00-course.md` lists Module 203's SLTs in a different order than the lessons (and `outline.md`). This assignment follows the **lesson** order. `00-course.md` should be reconciled._

--- a/lessons/204/assignment.md
+++ b/lessons/204/assignment.md
@@ -1,0 +1,51 @@
+# Assignment 204: CBOR Round-Trip and the One-Shot NFT
+
+## Artifact
+
+A Go toolkit that works at the byte level: it mints a one-shot NFT from a parameterized validator, observes that mint with Adder and identifies the contract interaction inside the event, and decodes an on-chain datum/redeemer, modifies it, and re-encodes it for a new transaction — backed by a short note mapping the bytes to their Protobuf and CDDL definitions.
+
+## Required Task
+
+This module lifts the lid on the binary formats the libraries handled for you. Build a small toolkit around the `hello_world` contract from Module 203 that does the encoding and decoding *yourself*:
+
+- **Parameterize and mint a one-shot NFT** — add an `OutputReference` parameter to the `hello_world` validator, apply it with `aiken blueprint apply`, and mint a token whose policy ID is unique to a single consumed UTxO (quantity 1, un-repeatable) (204.2).
+- **Observe and identify** — run an Adder watcher (Module 201) and, when your mint lands, pull the **contract interaction** out of the event payload — the redeemer / minted asset that proves a script ran (204.3).
+- **Decode** — take a real on-chain datum or redeemer CBOR (your 203 lock datum, or this mint's redeemer) and decode it back into Apollo `PlutusData` with `UnmarshalCBOR`, extracting the fields by `PlutusDataType` (204.1).
+- **Modify and re-encode** — change a field in that decoded value (e.g. the datum's `owner`, or add a field) and re-encode it to valid CBOR, then use it in a new transaction. The round-trip must preserve indefinite-length arrays so the canonical bytes still validate (204.4).
+- **Map the bytes** — write a short note that traces one field you handled to its definition in **two** schemas: the **Protobuf** spec Cardano's UTxORPC/gRPC interfaces use (204.5), and the **CDDL** specification in `cardano-ledger` (204.6).
+
+This is the DNS CLI's data layer at its most precise: a one-shot NFT is exactly how you guarantee a registered **name is unique**, and decode→modify→re-encode is how the CLI would **read and update a name record** stored in a datum.
+
+## Additional Exploration
+
+Make the round-trip mean something: decode the datum from your 203 lock UTxO, rewrite it into a "name record" datum (`owner` + a record string), re-encode it, lock a new output with the modified datum, then read it back off-chain and confirm the bytes survived the trip. That's a working name-record update.
+
+## Deliverables
+
+1. **Code** — public repo or gist with the toolkit (parameterized mint, Adder identify, decode, modify + re-encode) and the applied `plutus.json`. README explains how to run each step.
+2. **One-shot NFT** — tx hash on [Cardanoscan Preprod](https://preprod.cardanoscan.io/) showing quantity **exactly 1** under your final (unique) policy ID, with the parameter UTxO appearing in the transaction's **inputs**.
+3. **Adder identification** — captured watcher output for the mint, plus your code's report of the contract interaction found inside the event (the redeemer and/or minted asset).
+4. **CBOR round-trip** — for a real datum/redeemer: the decoded `PlutusData` fields (204.1), then the **before/after CBOR hex** of a modified value re-encoded (204.4), and the transaction (or tx body) that used the re-encoded value.
+5. **Byte-level reference note** — one data field traced to (a) its message/field in the **UTxORPC Protobuf** spec, and (b) its rule in the **`cardano-ledger` CDDL**. Cite the specific message/field name and CDDL rule.
+6. **Course feedback (required):** Written feedback on Module 204's lessons covering:
+   - **Quality** — what was clear, what was confusing, what was missing.
+   - **Correctness** — any code that didn't run, commands that failed, or steps that were wrong/out of date (cite the lesson number, e.g. 204.2).
+
+## Assessment Criteria
+
+- **SLT 204.1** — pass when on-chain CBOR is decoded into `PlutusData` and the fields are correctly extracted, type-asserted by `PlutusDataType` (not by assumption).
+- **SLT 204.2** — pass when a parameterized validator is compiled and applied (`aiken blueprint apply`) and a one-shot NFT is minted: quantity 1, unique policy ID, parameter UTxO consumed in the inputs.
+- **SLT 204.3** — pass when an Adder event for a contract transaction is captured and the contract interaction inside it (redeemer / minted asset) is correctly identified.
+- **SLT 204.4** — pass when a decoded `PlutusData` is modified and re-encoded to valid CBOR with indefinite-length arrays preserved, and the result is used in / accepted for a transaction.
+- **SLT 204.5** — pass when the learner correctly maps a data field to its definition in a Cardano Protobuf spec (UTxORPC).
+- **SLT 204.6** — pass when the learner cites the CDDL definition (`cardano-ledger`) for a specific transaction component they handled.
+- **Course feedback** — pass when feedback is specific and lesson-referenced (not "it was good"); flags at least one correctness issue OR one concrete improvement.
+
+## Notes
+
+- Builds directly on Module 203's `hello_world` contract. Requires the **Aiken toolchain** (`aiken build`, `aiken blueprint apply`) for 204.2, **Apollo** for decode/encode, a **Blockfrost preprod** ChainContext, and **Adder** for 204.3. Preprod network magic is `1`.
+- **Re-encoding gotcha:** Plutus emits indefinite-length arrays (`9f … ff`). Always rebuild with `PlutusIndefArray` — a definite array re-encodes to different canonical bytes and the validator/hash check fails (204.1, 204.4).
+- **`OutputReference` parameter CBOR** is a constructor with two fields *in order*: `transaction_id` (`#bytes`, 32) then `output_index` (`#integer`). Swapping them bakes the wrong UTxO into the script.
+- **Protobuf (204.5):** Cardano's **UTxORPC** spec is the natural target — it's the gRPC interface Dolos exposes. Read its `.proto` definitions for the field you handled.
+- **CDDL (204.6):** use the CDDL from **`cardano-ledger`** — the canonical schema for every transaction byte.
+- **Security:** keep mnemonic/keys out of git; submit tx hashes and public identifiers only.


### PR DESCRIPTION
## What

Adds a standalone `assignment.md` for eight modules and fixes the Module 203 SLT ordering in `00-course.md`.

Each assignment follows a shared template (Artifact / Required Task / Additional Exploration / Deliverables / Assessment Criteria / Notes) and bakes in the course conventions:

- **Working Go code artifact** as the deliverable
- **Learner feedback on the lessons** (quality + correctness) is a *required* deliverable — unique to this course
- Framed as steps toward the **Phase 2 DNS CLI**
- Scoped to **preprod** (magic `1`), no Demeter
- Evidence is **agent-gradable** (repo links, preprod tx hashes, captured output)

## Assignments

| Module | Title | Closes |
|--------|-------|--------|
| 099 | Address Balance Toolkit (pure Go) | #34 |
| 100 | Create a wallet with Bursa + tools field guide | #35 |
| 101 | Node Inspector CLI (gOuroboros) | #36 |
| 102 | Transaction Sender (Bursa + Apollo + gOuroboros) | #37 |
| 201 | Filtered Chain Watcher (Adder) | #38 |
| 202 | Hybrid Address Indexer | #39 |
| 203 | Hello World Contract Lifecycle | #40 |
| 204 | CBOR Round-Trip and the One-Shot NFT | #41 |

301 (#42) and 302 (#43) are intentionally deferred.

## Notes for reviewers

- **203 SLT order**: `00-course.md` listed 203's SLTs in a different order than the lessons/`outline.md`; corrected to match the lessons.
- **Drafted-ahead modules**: 101, and the back half of 102 (102.4–102.6), have assignments drafted before their lessons exist (Andamio-encouraged). Each flags this in its Notes for reconciliation once lessons land.
- **Weight**: 102 and 203 require multiple on-chain transactions — heavier than 201/202. Called out in earlier discussion; open to trimming if the team prefers parity.
- The `draft-assignments` skill used to generate these lives under `.claude/skills/` (gitignored), so it is not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)